### PR TITLE
Add TypeScript types

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "author": "Brian Vaughn <brian.david.vaughn@gmail.com>",
   "license": "MIT",
   "main": "src/index.js",
+  "types": "types/index.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/bvaughn/progress-estimator.git"
@@ -14,8 +15,8 @@
   },
   "scripts": {
     "linc": "lint-staged",
-    "lint": "eslint 'src/**/*.js'",
-    "prettier": "prettier --write 'src/**/*.js'"
+    "lint": "eslint 'src/**/*.js' && tsc --project types",
+    "prettier": "prettier --write 'src/**/*.js' 'types/**/*.ts'"
   },
   "lint-staged": {
     "src/**/*.js": "eslint 'src/**/*.js' --max-warnings 0"
@@ -32,6 +33,7 @@
     "eslint-config-prettier": "^3.3.0",
     "eslint-plugin-prettier": "^3.0.0",
     "lint-staged": "^8.1.0",
-    "prettier": "^1.15.2"
+    "prettier": "^1.15.2",
+    "typescript": "^3.1.6"
   }
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,36 @@
+import { Chalk } from 'chalk';
+
+export interface Spinner {
+  interval: number;
+  frames: string[];
+}
+
+export interface ChalkTheme extends Chalk {
+  asciiCompleted: Chalk;
+  asciiInProgress: Chalk;
+  estimate: Chalk;
+  label: Chalk;
+  percentage: Chalk;
+  progressBackground: Chalk;
+  progressForeground: Chalk;
+}
+
+export interface Configuration {
+  spinner?: Spinner;
+  storagePath?: string;
+  theme?: ChalkTheme;
+}
+
+export interface ProgressEstimator {
+  <T>(promise: Promise<T>, label: string, estimatedDuration?: number): Promise<
+    T
+  >;
+  configure(options: Configuration): void;
+  logProgress: ProgressEstimator;
+}
+
+export declare const configure: (options: Configuration) => void;
+export declare const logProgress: ProgressEstimator;
+
+declare const progressEstimator: ProgressEstimator;
+export default progressEstimator;

--- a/types/test.ts
+++ b/types/test.ts
@@ -1,0 +1,49 @@
+import chalk from 'chalk';
+import progressEstimator, { configure, logProgress, ChalkTheme } from '..';
+
+// Test promises
+const stringPromise = new Promise<string>(resolve => resolve('hello'));
+const numberPromise = new Promise<number>(resolve => resolve(10));
+
+// Chalk theme
+const chalkTheme = chalk.constructor() as ChalkTheme;
+chalkTheme.asciiCompleted = chalkTheme;
+chalkTheme.asciiInProgress = chalkTheme;
+chalkTheme.estimate = chalkTheme;
+chalkTheme.label = chalkTheme;
+chalkTheme.percentage = chalkTheme;
+chalkTheme.progressBackground = chalkTheme;
+chalkTheme.progressForeground = chalkTheme;
+
+// Check `logProgress`
+const resultOne: Promise<string> = progressEstimator(
+  stringPromise,
+  'This promise has no initial estimate'
+);
+const resultTwo: Promise<number> = progressEstimator(
+  numberPromise,
+  'This promise is initially estimated to take 1 second',
+  1000
+);
+const resultThree: Promise<number> = logProgress(numberPromise, 'Valid export');
+
+// Check `configure`
+configure({
+  spinner: { interval: 100, frames: ['.', ''] }
+});
+configure({
+  storagePath: 'path/to/dir'
+});
+configure({
+  theme: chalkTheme
+});
+configure({
+  spinner: { interval: 100, frames: ['.', ''] },
+  storagePath: 'path/to/dir',
+  theme: chalkTheme
+});
+progressEstimator.configure({
+  spinner: { interval: 100, frames: ['.', ''] },
+  storagePath: 'path/to/dir',
+  theme: chalkTheme
+});

--- a/types/tsconfig.json
+++ b/types/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es6",
+    "lib": ["es2015"],
+    "noImplicitAny": true,
+    "noUnusedLocals": false,
+    "noEmit": true,
+    "allowJs": true
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2052,6 +2052,11 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
+typescript@^3.1.6:
+  version "3.1.6"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.1.6.tgz#b6543a83cfc8c2befb3f4c8fba6896f5b0c9be68"
+  integrity sha512-tDMYfVtvpb96msS1lDX9MEdHrW4yOuZ4Kdc4Him9oU796XldPYF/t2+uKoX0BBa0hXXwDlqYQbXY5Rzjzc5hBA==
+
 union-value@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/union-value/-/union-value-1.0.0.tgz#5c71c34cb5bad5dcebe3ea0cd08207ba5aa1aea4"


### PR DESCRIPTION
Super awesome package!  This PR adds TypeScript type definitions so that anybody using TypeScript can easily use this in their own project.  It's set up the same way that `chalk` includes TypeScript types.